### PR TITLE
Implement styles for the new gradient theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -22,17 +22,45 @@
   --background-image-sm: url("/public/images/Phone D.svg");
 }
 
+@keyframes gradient {
+  0% {
+    background-position: 15% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 15% 50%;
+  }
+}
+
+[data-theme="gradient"] {
+  --koii-blue: #171753;
+  --koii-white: #ecfffe;
+  --koii-mint: #5ed9d1;
+  --background-image: linear-gradient(
+    43deg,
+    rgb(65, 88, 208) 0%,
+    rgb(200, 80, 192) 66%,
+    rgb(255, 204, 112) 100%
+  );
+  --background-image-md: var(--background-image);
+  --background-image-sm: var(--background-image);
+  --animation: 10s ease 0s infinite normal none running gradient;
+  --background-size: 150% 150%;
+}
+
 body {
   margin: 0;
   font-family: "Sora", sans-serif !important;
   overflow-x: hidden;
-  min-width: 100vw;
-  min-height: 100vh;
+  min-width: 100vw !important;
+  min-height: 100vh !important;
   background-image: var(--background-image) !important;
-  background-position: center !important;
-  background-size: cover !important;
+  background-size: var(--background-size, cover) !important;
   background-repeat: no-repeat !important;
   background-attachment: fixed !important;
+  animation: var(--animation) !important;
   color: var(--koii-white) !important;
   display: flex;
   justify-content: center;
@@ -108,14 +136,16 @@ input[type="file"]:focus::file-selector-button {
 }
 
 @media screen and (max-width: 800px) {
-  body {
+  body[data-theme="dark"],
+  body[data-theme="light"] {
     background-image: var(--background-image-md) !important;
     background-position: bottom !important;
   }
 }
 
 @media screen and (max-width: 700px) {
-  body {
+  body[data-theme="dark"],
+  body[data-theme="light"] {
     background-image: var(--background-image-sm) !important;
     background-position: top !important;
   }


### PR DESCRIPTION
### :ticket: Ticket: 
- 🦄 

### :factory: What was done: 
- Were added the styles for the new `gradient` theme, especially the background gradient and the animation that gives it a moment.
- Was fixed the body's width and height, especially the latter for some reason gets converted to 100% when building (instead of 100vh). I assume it's the same reason why we're using !important everywhere.
- Some selectors were made more specific to not apply to the new theme, but only for the other ones.

### 🗒️  Notes: 
- Of course all the screen sizes were taken into account, so all of them should look good :)

### 🖼️  Screenshots: 

https://github.com/koii-network/linktree-app/assets/52573144/4ab31de9-2b1e-41ee-8d78-22f34f8c1585

